### PR TITLE
[GATE 1775] User agent

### DIFF
--- a/lib/vivialconnect/client.rb
+++ b/lib/vivialconnect/client.rb
@@ -3,6 +3,7 @@ require 'addressable'
 require 'digest'
 require 'openssl'
 require 'singleton'
+require 'json'
 
 module VivialConnect 
 
@@ -207,12 +208,22 @@ module VivialConnect
     def create_request_headers
       headers = {}
       headers['Content-Type'] = 'application/json'
-      headers['Host'] = 'api.vivialconnect.net'
+      headers['Host'] = host
       headers['X-Auth-Date'] = request_timestamp
       headers['X-Auth-SignedHeaders'] = 'accept;date;host'
       headers['Authorization'] = "HMAC" + " " + api_key + ":" + hmac_sha256
       headers['Date'] = date_for_date_header
       headers['Accept'] = 'application/json'
+      headers['User-Agent'] = 'VivialConnect RubyClient ' + Vivialconnect::VERSION
+
+      xUserAgent = {}
+      xUserAgent['lang'] = 'Ruby'
+      xUserAgent['lang_version'] = "#{RUBY_DESCRIPTION}"
+      xUserAgent['publisher'] = 'vivialconnect'
+      xUserAgent['client_version'] = Vivialconnect::VERSION
+      xUserAgent['platform'] = "#{RUBY_PLATFORM}"
+
+      headers['X-VivialConnect-User-Agent'] = JSON.generate(xUserAgent)
       headers
     end
 

--- a/vivialconnect.gemspec
+++ b/vivialconnect.gemspec
@@ -38,8 +38,9 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'faraday', '~>0.11.0'
   spec.add_dependency 'addressable', '~> 2.5', '>= 2.5.0'
+  spec.add_dependency 'json', '>= 1.0'
 
-  spec.add_development_dependency 'bundler', '~> 1.14'
+  spec.add_development_dependency 'bundler', '>= 1.14'
   spec.add_development_dependency 'dotenv', '~> 2.2', '>= 2.2.0'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'


### PR DESCRIPTION
Added the User-Agent and X-VivialConnect-User-Agent headers. Example HTTP headers:
```
{
 "Accept"=>"application/json",
 "Authorization"=>"HMAC MTK4AHJ1NB8QBEPPRAKKDJ9AK2L0Z5GBPOU:c0261e8d72c9ade0dc47708aa57c800e1b09b0d7d02e0f1b23235f4c391becce",
 "Content-Type"=>"application/json",
 "Date"=>"Tue, 05 Dec 2017 16:51:41 GMT",
 "Host"=>"https://api-stage-8c935d.moosetalk.net/api/",
 "User-Agent"=>"VivialConnect RubyClient 0.0.5",
 "X-Auth-Date"=>"20171205T165141Z",
 "X-Auth-SignedHeaders"=>"accept;date;host",
 "X-VivialConnect-User-Agent"=>"{\"lang\":\"Ruby\",\"lang_version\":\"ruby 2.3.1p112 (2016-04-26) [x86_64-linux-gnu]\",\"publisher\":\"vivialconnect\",\"client_version\":\"0.0.5\",\"platform\":\"x86_64-linux-gnu\"}",
}
```